### PR TITLE
Update to manage Drools  version 6.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/target
+.classpath
+.project
+.settings/
+

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,14 @@
 
     <groupId>pl.maciejwalkowiak</groupId>
     <artifactId>junit-drools</artifactId>
-    <version>1.0</version>
+    <version>1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>junit-drools</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <drools.version>6.0.1.Final</drools.version>
     </properties>
 
     <dependencies>
@@ -23,13 +24,13 @@
         <dependency>
             <groupId>org.drools</groupId>
             <artifactId>drools-core</artifactId>
-            <version>5.5.0.Final</version>
+            <version>${drools.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.drools</groupId>
             <artifactId>drools-compiler</artifactId>
-            <version>5.5.0.Final</version>
+            <version>${drools.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/pl/maciejwalkowiak/drools/DroolsInjector.java
+++ b/src/main/java/pl/maciejwalkowiak/drools/DroolsInjector.java
@@ -1,11 +1,11 @@
 package pl.maciejwalkowiak.drools;
 
-import org.drools.RuleBase;
-import org.drools.RuleBaseFactory;
-import org.drools.StatefulSession;
-import org.drools.compiler.DroolsError;
-import org.drools.compiler.PackageBuilder;
-import org.drools.compiler.PackageBuilderErrors;
+import org.drools.compiler.compiler.DroolsError;
+import org.drools.compiler.compiler.PackageBuilder;
+import org.drools.compiler.compiler.PackageBuilderErrors;
+import org.drools.core.RuleBase;
+import org.drools.core.RuleBaseFactory;
+import org.drools.core.StatefulSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.maciejwalkowiak.drools.annotations.DroolsFiles;

--- a/src/main/java/pl/maciejwalkowiak/drools/DroolsSession.java
+++ b/src/main/java/pl/maciejwalkowiak/drools/DroolsSession.java
@@ -1,6 +1,6 @@
 package pl.maciejwalkowiak.drools;
 
-import org.drools.StatefulSession;
+import org.drools.core.StatefulSession;
 
 /**
  * Simplified interface of Drools {@link StatefulSession}

--- a/src/main/java/pl/maciejwalkowiak/drools/DroolsSessionImpl.java
+++ b/src/main/java/pl/maciejwalkowiak/drools/DroolsSessionImpl.java
@@ -1,7 +1,7 @@
 package pl.maciejwalkowiak.drools;
 
-import org.drools.StatefulSession;
-import org.drools.base.RuleNameEqualsAgendaFilter;
+import org.drools.core.StatefulSession;
+import org.drools.core.base.RuleNameEqualsAgendaFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/test/java/pl/maciejwalkowiak/drools/BeforeMethodBasedTest.java
+++ b/src/test/java/pl/maciejwalkowiak/drools/BeforeMethodBasedTest.java
@@ -1,6 +1,6 @@
 package pl.maciejwalkowiak.drools;
 
-import org.drools.StatefulSession;
+import org.drools.core.StatefulSession;
 import org.junit.Before;
 import org.junit.Test;
 import pl.maciejwalkowiak.drools.annotations.DroolsFiles;

--- a/src/test/java/pl/maciejwalkowiak/drools/RunnerBasedTest.java
+++ b/src/test/java/pl/maciejwalkowiak/drools/RunnerBasedTest.java
@@ -1,6 +1,6 @@
 package pl.maciejwalkowiak.drools;
 
-import org.drools.StatefulSession;
+import org.drools.core.StatefulSession;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import pl.maciejwalkowiak.drools.annotations.DroolsFiles;


### PR DESCRIPTION
I updated the sources to manage the 6.0.1 version of Drools.
I tested it removing the ar.com.synergian part and the synergian-repo part in the pom.xml as i don't use it.
Regards
Samuel-A. Massot
