### PR TITLE
Update to use the kie package structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 .project
 .settings/
 *.iml
+*.iws
+*.ipr
 .idea/

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ I am not very experienced with Drools so the library actually does what was need
     <dependency>
         <groupId>pl.maciejwalkowiak</groupId>
         <artifactId>junit-drools</artifactId>
-        <version>1.0</version>
+        <version>2.0</version>
         <scope>test</scope>
     </dependency>
 ```
@@ -72,7 +72,7 @@ Lets consider following example:
     public class AppTest {
     
         @DroolsSession
-        StatefulSession session;
+        KieSession session;
     
         @Test
         public void should_set_discount() {
@@ -97,8 +97,8 @@ Lets consider following example:
 
 - **@RunWith(DroolsJUnitRunner)** - inits JUnit runner for testing drools rules
 - **@DroolsFiles** - for specifying the content for the rules session
-  - **@DroolsFiles#value** is a set of drl files. drl files have to be on class path
-  - **@DroolsFiles#dsl** is an optional DSL used for building the drl files
+  - **@DroolsFiles#value** is a set of drl or dslr files. files have to be on class path
+  - **@DroolsFiles#dsl** is an optional DSL used for building the dslr files
   - **@DroolsFiles#location** is relative to ```src/test/resources``` or ```src/main/resources```
 - **@DroolsSession** - autoinjects Drools session to your test before execution
 
@@ -109,7 +109,7 @@ In case you don't want to use DroolsJUnitRunner, for example because you already
     @DroolsFiles(value = "helloworld.drl", location = "/drl/")
     public class BeforeMethodBasedTest {
         @DroolsSession
-        StatefulSession session;
+        KieSession session;
     
         @Before
         public void initDrools() throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
 
     <groupId>pl.maciejwalkowiak</groupId>
     <artifactId>junit-drools</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>junit-drools</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <drools.version>6.0.1.Final</drools.version>
+        <drools.version>6.2.0.CR2</drools.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/pl/maciejwalkowiak/drools/DroolsAnnotationProcessor.java
+++ b/src/main/java/pl/maciejwalkowiak/drools/DroolsAnnotationProcessor.java
@@ -29,27 +29,21 @@ public class DroolsAnnotationProcessor {
         return droolsFiles;
     }
 
-    List<Field> getAllFields() {
-        List<Field> allFields = new LinkedList<Field>();
+    public void setDroolsSession(pl.maciejwalkowiak.drools.DroolsSession droolsSession) {
         Class<?> klass = testClass.getClass();
         while (klass != null) {
-            allFields.addAll(Arrays.asList(klass.getDeclaredFields()));
-            klass = klass.getSuperclass();
-        }
-        return allFields;
-    }
-
-    public void setDroolsSession(pl.maciejwalkowiak.drools.DroolsSession droolsSession) {
-        for (Field field : getAllFields()) {
-            field.setAccessible(true);
-            if (field.isAnnotationPresent(DroolsSession.class)) {
-                Object value = getValueToSet(droolsSession, field);
-                try {
-                    field.set(testClass, value);
-                } catch (IllegalAccessException e) {
-                    throw new RuntimeException(e);
+            for (Field field : klass.getDeclaredFields()) {
+                if (field.isAnnotationPresent(DroolsSession.class)) {
+                    field.setAccessible(true);
+                    Object value = getValueToSet(droolsSession, field);
+                    try {
+                        field.set(testClass, value);
+                    } catch (IllegalAccessException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
             }
+            klass = klass.getSuperclass();
         }
     }
 

--- a/src/main/java/pl/maciejwalkowiak/drools/DroolsAnnotationProcessor.java
+++ b/src/main/java/pl/maciejwalkowiak/drools/DroolsAnnotationProcessor.java
@@ -4,6 +4,9 @@ import pl.maciejwalkowiak.drools.annotations.DroolsFiles;
 import pl.maciejwalkowiak.drools.annotations.DroolsSession;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Processes test class annotations
@@ -23,17 +26,24 @@ public class DroolsAnnotationProcessor {
         if (droolsFiles == null) {
             throw new IllegalStateException("DroolsFiles annotation not set");
         }
-
         return droolsFiles;
     }
 
-    public void setDroolsSession(pl.maciejwalkowiak.drools.DroolsSession droolsSession) {
-        for (Field field : testClass.getClass().getDeclaredFields()) {
-            field.setAccessible(true);
+    List<Field> getAllFields() {
+        List<Field> allFields = new LinkedList<Field>();
+        Class<?> klass = testClass.getClass();
+        while (klass != null) {
+            allFields.addAll(Arrays.asList(klass.getDeclaredFields()));
+            klass = klass.getSuperclass();
+        }
+        return allFields;
+    }
 
+    public void setDroolsSession(pl.maciejwalkowiak.drools.DroolsSession droolsSession) {
+        for (Field field : getAllFields()) {
+            field.setAccessible(true);
             if (field.isAnnotationPresent(DroolsSession.class)) {
                 Object value = getValueToSet(droolsSession, field);
-
                 try {
                     field.set(testClass, value);
                 } catch (IllegalAccessException e) {

--- a/src/main/java/pl/maciejwalkowiak/drools/DroolsSession.java
+++ b/src/main/java/pl/maciejwalkowiak/drools/DroolsSession.java
@@ -1,18 +1,21 @@
 package pl.maciejwalkowiak.drools;
 
-import org.drools.core.StatefulSession;
+import org.kie.api.runtime.KieSession;
 
 /**
- * Simplified interface of Drools {@link StatefulSession}
+ * Simplified interface of Drools {@link KieSession}
  *
  * @author Maciej Walkowiak
  */
 public interface DroolsSession {
+
     void fire(String ruleName);
 
     void fireAllRules();
 
     void insert(Object object);
 
-    StatefulSession getStatefulSession();
+    void retract();
+
+    KieSession getStatefulSession();
 }

--- a/src/main/java/pl/maciejwalkowiak/drools/DroolsSessionImpl.java
+++ b/src/main/java/pl/maciejwalkowiak/drools/DroolsSessionImpl.java
@@ -1,43 +1,52 @@
 package pl.maciejwalkowiak.drools;
 
-import org.drools.core.StatefulSession;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.drools.core.base.RuleNameEqualsAgendaFilter;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.rule.FactHandle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Can be injected instead of {@link StatefulSession} in test classes to improve readability in case if only basic methods are used
+ * Can be injected instead of {@link org.kie.api.runtime.KieSession} in test classes to improve readability in case if only basic methods are used
  *
  * @author Maciej Walkowiak
  */
 public class DroolsSessionImpl implements DroolsSession {
     private static final Logger LOG = LoggerFactory.getLogger(DroolsSessionImpl.class);
 
-    private StatefulSession statefulSession;
+    private KieSession kieSession;
 
-    public DroolsSessionImpl(StatefulSession statefulSession) {
-        this.statefulSession = statefulSession;
+    private List<FactHandle> handles;
+
+    public DroolsSessionImpl(KieSession session) {
+        this.kieSession = session;
+        this.handles = new ArrayList<FactHandle>();
     }
 
-    @Override
     public void fire(String ruleName) {
         LOG.debug("Firing rule: {}", ruleName);
-
-        this.statefulSession.fireAllRules(new RuleNameEqualsAgendaFilter(ruleName));
+        this.kieSession.fireAllRules(new RuleNameEqualsAgendaFilter(ruleName));
     }
 
-    @Override
     public void fireAllRules() {
-        this.statefulSession.fireAllRules();
+        this.kieSession.fireAllRules();
     }
 
-    @Override
     public void insert(Object object) {
-        this.statefulSession.insert(object);
+        handles.add(this.kieSession.insert(object));
     }
 
-    @Override
-    public StatefulSession getStatefulSession() {
-        return statefulSession;
+    public void retract() {
+        for (FactHandle handle : handles) {
+            kieSession.delete(handle);
+            handles.remove(handle);
+        }
+    }
+
+    public KieSession getStatefulSession() {
+        return kieSession;
     }
 }

--- a/src/main/java/pl/maciejwalkowiak/drools/annotations/DroolsSession.java
+++ b/src/main/java/pl/maciejwalkowiak/drools/annotations/DroolsSession.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to inject Drools {@link org.drools.StatefulSession}
+ * Used to inject Drools {@link org.kie.api.runtime.KieSession}
  * or {@link pl.maciejwalkowiak.drools.DroolsSession} depending on what type annotated property is
  *
  * @author Maciej Walkowiak

--- a/src/test/java/pl/maciejwalkowiak/drools/BeforeMethodBasedTest.java
+++ b/src/test/java/pl/maciejwalkowiak/drools/BeforeMethodBasedTest.java
@@ -1,17 +1,17 @@
 package pl.maciejwalkowiak.drools;
 
-import org.drools.core.StatefulSession;
+import static org.junit.Assert.*;
+
 import org.junit.Before;
 import org.junit.Test;
+import org.kie.api.runtime.KieSession;
 import pl.maciejwalkowiak.drools.annotations.DroolsFiles;
 import pl.maciejwalkowiak.drools.annotations.DroolsSession;
 
-import static org.junit.Assert.assertTrue;
-
 @DroolsFiles(value = "helloworld.drl", location = "/drl/")
 public class BeforeMethodBasedTest {
-    @DroolsSession
-    StatefulSession session;
+
+    @DroolsSession KieSession session;
 
     @Before
     public void initDrools() throws Exception {

--- a/src/test/java/pl/maciejwalkowiak/drools/RunnerBasedTest.java
+++ b/src/test/java/pl/maciejwalkowiak/drools/RunnerBasedTest.java
@@ -1,19 +1,19 @@
 package pl.maciejwalkowiak.drools;
 
-import org.drools.core.StatefulSession;
+import static org.junit.Assert.*;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.KieSession;
 import pl.maciejwalkowiak.drools.annotations.DroolsFiles;
 import pl.maciejwalkowiak.drools.annotations.DroolsSession;
-
-import static org.junit.Assert.*;
 
 @RunWith(DroolsJUnitRunner.class)
 @DroolsFiles(value = "helloworld.drl", location = "/drl/")
 public class RunnerBasedTest {
 
-    @DroolsSession
-    StatefulSession session;
+    @DroolsSession KieSession session;
 
     @Test
     public void should_set_discount() {


### PR DESCRIPTION
As an inexperienced user of Drools myself, I had no idea the previous package format was deprecated a long time ago to this kie package structure. This change-set updates to that package structure and will be compatible with drools >6. Interestingly, the dsl as an additional argument really isn't necessary as we just load in all the files necessary into the kieFileSystem, but I've left it separate for clarity.

I realize you may not be wanting to upgrade yet, but if you want to use Java8 features an upgrade is necessary.
